### PR TITLE
Save Line Breaks in Returns Description Section

### DIFF
--- a/classes/EbayReturnsPolicyConfiguration.php
+++ b/classes/EbayReturnsPolicyConfiguration.php
@@ -61,7 +61,7 @@ class EbayReturnsPolicyConfiguration extends ObjectModel
 
         $fields['ebay_returns_within'] = pSQL($this->ebay_returns_within);
         $fields['ebay_returns_who_pays'] = pSQL($this->ebay_returns_who_pays);
-        $fields['ebay_returns_description'] = pSQL($this->ebay_returns_description);
+        $fields['ebay_returns_description'] = pSQL($this->ebay_returns_description, true);
         $fields['ebay_returns_accepted_option'] = pSQL($this->ebay_returns_accepted_option);
 
         return $fields;


### PR DESCRIPTION
This fix saves the Returns Description including the line breaks correctly.